### PR TITLE
Bump up jquery version to 3.7.0

### DIFF
--- a/search.html
+++ b/search.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="./css/theme_extra.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" />
   
-  <script src="./js/jquery-2.1.1.min.js" defer></script>
+  <script src="./js/jquery-3.7.0.min.js" defer></script>
   <script src="./js/modernizr-2.8.3.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
   <script>hljs.initHighlightingOnLoad();</script> 


### PR DESCRIPTION
This is to fix multiple jquery version related issues:
https://github.com/oap-project/oap-project.github.io/security/dependabot/12
https://github.com/oap-project/oap-project.github.io/security/dependabot/16
https://github.com/oap-project/oap-project.github.io/security/dependabot/15
https://github.com/oap-project/oap-project.github.io/security/dependabot/14
https://github.com/oap-project/oap-project.github.io/security/dependabot/13
and so on.
